### PR TITLE
fix: handle empty string in `util.Int64Value`

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -52,6 +52,9 @@ func Int64Value[T int64 | string](value T, diagnostics *diag.Diagnostics) types.
 	case int64:
 		return types.Int64Value(v)
 	case string:
+		if v == "" {
+			return types.Int64Null()
+		}
 		if i, err := strconv.ParseInt(v, 10, 64); err == nil {
 			return types.Int64Value(i)
 		}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -139,6 +139,11 @@ func TestInt64Value(t *testing.T) {
 			want:  types.Int64Value(42),
 		},
 		{
+			name:  "empty string",
+			value: "",
+			want:  types.Int64Null(),
+		},
+		{
 			name:  "string invalid",
 			value: "invalid",
 			want:  types.Int64Null(),


### PR DESCRIPTION
In some cases, the Porkbun API may return `null` in the `prio` field of a DNS record, which is converted to an empty string by the tuzzmaniandevil/porkbun-go library.

The previous implementationa tried to parse this empty string as an integer, leading to an error.

This commit adds a special-case for empty strings, converting them to a `Int64Null`. This means Terraform should recognize the drift between the API state (null) and intended state (0) and fix it on the next apply.

See #42